### PR TITLE
ci, chore, build: update node version for actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "14.18.1"
+          node-version: "16.20.0"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
 
       - name: Setup Pages

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "14.18.1"
+          node-version: "16.20.0"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
 
       - name: Install dependencies


### PR DESCRIPTION
Fix the Node.js version for GitHub Actions