### PR TITLE
Fix GA pageview type mismatch

### DIFF
--- a/hooks/use-effect-page-view-ga.ts
+++ b/hooks/use-effect-page-view-ga.ts
@@ -12,7 +12,7 @@ export const useEffectPageView = () => {
       return;
     }
 
-    const handleRouteChange = (url: URL) => {
+    const handleRouteChange = (url: string) => {
       pageview(url, document.title);
     };
 

--- a/lib/gtag.ts
+++ b/lib/gtag.ts
@@ -8,7 +8,7 @@ interface GenerateClickEventParams {
 }
 
 // https://developers.google.com/analytics/devguides/collection/ga4/views?client_type=gtag
-export const pageview = (url: URL, title: string) => {
+export const pageview = (url: string, title: string) => {
   window.gtag('config', GA_TRACKING_ID, {
     page_location: url,
     page_title: title,


### PR DESCRIPTION
## Summary
- align GA pageview helpers with router events

## Testing
- `yarn lint` *(fails: Error when performing the request to https://repo.yarnpkg.com...)*
- `yarn typecheck` *(fails: Error when performing the request to https://repo.yarnpkg.com...)*

------
https://chatgpt.com/codex/tasks/task_e_687e7a40839c832a9e0509bb714d68b8