### PR TITLE
Rename cube component typo

### DIFF
--- a/components/common/icon-rectangle-box/CubeComponent.tsx
+++ b/components/common/icon-rectangle-box/CubeComponent.tsx
@@ -1,18 +1,18 @@
 import RectangleBoxIcon from './RectangleBoxIcon';
 import RectangleBoxIconInverse from './RectangleBoxIconInverse';
 
-import { СubeContainerStyled } from './styled-components';
+import { CubeContainerStyled } from './styled-components';
 
-interface СubeComponentProps {
+interface CubeComponentProps {
   isDarkTheme?: boolean;
 }
 
-const СubeComponent = ({ isDarkTheme }: СubeComponentProps) => {
+const CubeComponent = ({ isDarkTheme }: CubeComponentProps) => {
   return (
-    <СubeContainerStyled>
+    <CubeContainerStyled>
       {isDarkTheme ? <RectangleBoxIconInverse /> : <RectangleBoxIcon />}
-    </СubeContainerStyled>
+    </CubeContainerStyled>
   );
 };
 
-export default СubeComponent;
+export default CubeComponent;

--- a/components/common/icon-rectangle-box/styled-components.ts
+++ b/components/common/icon-rectangle-box/styled-components.ts
@@ -1,6 +1,6 @@
 import { styled } from '@mui/material/styles';
 
-export const СubeContainerStyled = styled('div')(({ theme }) => ({
+export const CubeContainerStyled = styled('div')(({ theme }) => ({
   position: 'absolute',
   left: '50%',
   marginTop: '-35px',

--- a/pages/[staticPageName].page.tsx
+++ b/pages/[staticPageName].page.tsx
@@ -9,7 +9,7 @@ import {
   type StaticPageProps,
 } from '../utils/api.static-page';
 
-import { СubeContainerStyled } from '../components/common/icon-rectangle-box/styled-components';
+import { CubeContainerStyled } from '../components/common/icon-rectangle-box/styled-components';
 import RectangleBoxIcon from '../components/common/icon-rectangle-box/RectangleBoxIcon';
 import { PageContainer } from '../components/case-studies/styled-components';
 import HeroStaticPage from '../components/hero/HeroHireEngineer';
@@ -40,7 +40,7 @@ import JsonLdWebPage from '../components/json-ld/WebPage';
 import JsonLdWebSite from '../components/json-ld/WebSite';
 import JsonLdWebBreadcrumb from '../components/json-ld/Breadcrumb';
 
-const СubeContainerTechStyled = styled(СubeContainerStyled)(({ theme }) => ({
+const CubeContainerTechStyled = styled(CubeContainerStyled)(({ theme }) => ({
   [theme.breakpoints.down('md')]: {
     display: 'block',
   },
@@ -78,9 +78,9 @@ export default function StaticPage({ data, hireEngineersLinks }: StaticPageProps
       <>
         <HeroStaticPage title={title} subtitle={description} />
 
-        <СubeContainerTechStyled>
+        <CubeContainerTechStyled>
           <RectangleBoxIcon />
-        </СubeContainerTechStyled>
+        </CubeContainerTechStyled>
 
         <PageContainer className="lightBackground">
           <ContainerDynamic maxWidth="lg">

--- a/pages/hire-engineers/[hireEngineerId].page.tsx
+++ b/pages/hire-engineers/[hireEngineerId].page.tsx
@@ -12,7 +12,7 @@ import type { HireEngineer, Collection } from '../../models';
 
 import { useGenerateEventGa } from '../../hooks/use-generate-event-ga';
 
-import { СubeContainerStyled } from '../../components/common/icon-rectangle-box/styled-components';
+import { CubeContainerStyled } from '../../components/common/icon-rectangle-box/styled-components';
 import { PageContainer } from '../../components/case-studies/styled-components';
 import { convertStrapiQuoteToFeedback } from '../../components/common/feedback/Feedback';
 
@@ -60,7 +60,7 @@ import {
   getStaticPathsHireEngineers,
 } from '../../utils/api.hire-engineers';
 
-const СubeContainerTechStyled = styled(СubeContainerStyled)(({ theme }) => ({
+const CubeContainerTechStyled = styled(CubeContainerStyled)(({ theme }) => ({
   [theme.breakpoints.down('md')]: {
     display: 'block',
   },
@@ -153,9 +153,9 @@ export default function HireEngineerPage({ data, hireEngineersLinks }: HireEngin
           }
         />
 
-        <СubeContainerTechStyled>
+        <CubeContainerTechStyled>
           <RectangleBoxIcon />
-        </СubeContainerTechStyled>
+        </CubeContainerTechStyled>
 
         <PageContainer className="lightBackground">
           <ContainerDynamic maxWidth="lg">

--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -23,7 +23,7 @@ const ImportantUpdateDynamic = dynamic(
 const ServicesDynamic = dynamic(() => import('../components/services/Services'));
 const CustomServicesDynamic = dynamic(() => import('../components/pricing/CustomServices'));
 const DiscoverDynamic = dynamic(() => import('../components/discover/Discover'));
-const СubeComponentDynamic = dynamic(
+const CubeComponentDynamic = dynamic(
   () => import('../components/common/icon-rectangle-box/CubeComponent'),
 );
 const CaseStudiesAllDynamic = dynamic(
@@ -97,7 +97,7 @@ export default function Home(props: HomeStaticProps) {
           <CaseStudiesAllDynamic data={caseStudies} parentId="homePage" />
         </CaseStudiesContainer>
 
-        <СubeComponentDynamic isDarkTheme={Settings.DarkThemeAvailable} />
+        <CubeComponentDynamic isDarkTheme={Settings.DarkThemeAvailable} />
 
         <ServicesDynamic data={services} />
 

--- a/pages/tech/index.page.tsx
+++ b/pages/tech/index.page.tsx
@@ -9,7 +9,7 @@ const TypographyDynamic = dynamic(() => import('@mui/material/Typography'));
 
 import { useGenerateEventGa } from '../../hooks/use-generate-event-ga';
 
-import { СubeContainerStyled } from '../../components/common/icon-rectangle-box/styled-components';
+import { CubeContainerStyled } from '../../components/common/icon-rectangle-box/styled-components';
 
 const SectionContainerStyled = styled('div')(({ theme }) => ({
   position: 'relative',
@@ -22,7 +22,7 @@ const SectionContainerStyled = styled('div')(({ theme }) => ({
   },
 }));
 
-const СubeContainerTechStyled = styled(СubeContainerStyled)(({ theme }) => ({
+const CubeContainerTechStyled = styled(CubeContainerStyled)(({ theme }) => ({
   [theme.breakpoints.down('md')]: {
     display: 'block',
   },
@@ -130,9 +130,9 @@ export default function TechPage({ data, hireEngineersLinks }: TechnologiesStati
           }
         />
 
-        <СubeContainerTechStyled>
+        <CubeContainerTechStyled>
           <RectangleBoxIcon />
-        </СubeContainerTechStyled>
+        </CubeContainerTechStyled>
 
         <ContainerDynamic
           maxWidth={false}
@@ -274,9 +274,9 @@ export default function TechPage({ data, hireEngineersLinks }: TechnologiesStati
           </ContainerDynamic>
         </SectionContainerStyled>
 
-        <СubeContainerTechStyled>
+        <CubeContainerTechStyled>
           <RectangleBoxIcon />
-        </СubeContainerTechStyled>
+        </CubeContainerTechStyled>
 
         <ContainerDynamic
           maxWidth={false}
@@ -321,9 +321,9 @@ export default function TechPage({ data, hireEngineersLinks }: TechnologiesStati
           <ServicesDynamic data={services} />
         </BoxDynamic>
 
-        <СubeContainerTechStyled>
+        <CubeContainerTechStyled>
           <RectangleBoxIcon />
-        </СubeContainerTechStyled>
+        </CubeContainerTechStyled>
 
         <ContainerDynamic
           maxWidth={false}


### PR DESCRIPTION
## Summary
- rename `СubeContainerStyled` (typo with Cyrillic character) to `CubeContainerStyled`
- update all imports and usages across components and pages
- adjust component names to use ASCII `Cube` prefix

## Testing
- `yarn typecheck`

------
https://chatgpt.com/codex/tasks/task_e_687e907c8118832ab3e452edcf2dbb56